### PR TITLE
remove mssql dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,4 @@
 {:deps    {cheshire           {:mvn/version "5.8.1"}
            clj-http           {:mvn/version "3.4.0"}
-           http-kit           {:mvn/version "2.6.0"}
-           org.babashka/mssql {:mvn/version "0.1.1"}}
+           http-kit           {:mvn/version "2.6.0"}}
  :aliases {:main {:main-opts ["-m" "thortech.main"]}}}


### PR DESCRIPTION
I'm unable to execute main.clj with this dep in place:

```
Error building classpath. Could not find artifact org.babashka:mssql:jar:0.1.1 in central (https://repo1.maven.org/maven2/)
```

Should we be doing this via a pod anyways?

```clojure
(require '[babashka.pods :as pods])
(pods/load-pod 'org.babashka/mssql "0.0.1")
```